### PR TITLE
Optimize Docker CI Workflow and Build Process

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,21 +42,20 @@ on:
       - '.ocamlformat-ignore'
       - 'geneweb.iss'
       - 'geneweb.opam.template'
-
+      
 env:
-  PLATFORMS: ${{ github.ref == 'refs/heads/master' && 'linux/arm64/v8,linux/amd64' || 'linux/amd64' }}
   IMAGE_NAME: "geneweb"
   PUSH_IMAGE: ${{ github.ref == 'refs/heads/master' }}
-  CACHE_FROM: type=gha,scope=${{ github.ref == 'refs/heads/master' && 'docker-build-master' || 'docker-build-pr' }}
-  CACHE_TO: type=gha,scope=${{ github.ref == 'refs/heads/master' && 'docker-build-master' || 'docker-build-pr' }},mode=max
 
 jobs:
-  build-images:
+  build-amd64:
     runs-on: ubuntu-latest
+    env:
+      CACHE_FROM: type=gha,scope=docker-build-amd64
+      CACHE_TO: type=gha,scope=docker-build-amd64,mode=max
     permissions:
       contents: read
       packages: write
-    
     steps:
       - uses: actions/checkout@v4
         with:
@@ -80,14 +79,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          platforms: ${{ env.PLATFORMS }}
+          platforms: linux/amd64
           driver-opts: |
             network=host
             image=moby/buildkit:latest
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        if: github.ref == 'refs/heads/master'
 
       - name: Login to GitHub Container Registry
         if: ${{ env.PUSH_IMAGE == 'true' }}
@@ -97,27 +92,83 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ github.token }}
 
-      - name: Cache Docker layers
-        uses: actions/cache@v4
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.ref_name }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-${{ github.ref_name }}-
-            ${{ runner.os }}-buildx-
+          context: .
+          file: docker/Dockerfile
+          target: container
+          platforms: linux/amd64
+          push: ${{ env.PUSH_IMAGE }}
+          tags: ${{ steps.docker-meta.outputs.tags }}
+          labels: ${{ steps.docker-meta.outputs.labels }}
+          cache-from: ${{ env.CACHE_FROM }}
+          cache-to: ${{ env.CACHE_TO }}
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+            BUILDKIT_PROGRESS=plain
+            FAST_BUILD=${{ github.ref != 'refs/heads/master' && '1' || '0' }}
+
+  build-arm64:
+    runs-on: ubuntu-latest
+    env:
+      CACHE_FROM: type=gha,scope=docker-build-arm64
+      CACHE_TO: type=gha,scope=docker-build-arm64,mode=max
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+          fetch-depth: 1
+
+      - name: Generate Docker image metadata
+        id: docker-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=edge,branch=master
+            type=sha,prefix=,format=short
+          labels: |
+            org.opencontainers.image.title=GeneWeb
+            org.opencontainers.image.description=Genealogy Software
+            maintainer=${{ github.repository_owner }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/arm64/v8
+          driver-opts: |
+            network=host
+            image=moby/buildkit:latest
+
+      - name: Login to GitHub Container Registry
+        if: ${{ env.PUSH_IMAGE == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-          context: docker/
+          context: .
           file: docker/Dockerfile
           target: container
-          platforms: ${{ env.PLATFORMS }}
+          platforms: linux/arm64/v8
           push: ${{ env.PUSH_IMAGE }}
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.docker-meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ github.ref_name }}
-          cache-to: type=gha,scope=${{ github.ref_name }},mode=max
+          cache-from: ${{ env.CACHE_FROM }}
+          cache-to: ${{ env.CACHE_TO }}
           build-args: |
             BUILDKIT_INLINE_CACHE=1
+            BUILDKIT_PROGRESS=plain
             FAST_BUILD=${{ github.ref != 'refs/heads/master' && '1' || '0' }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,33 +1,40 @@
 ###############################################################################
-#                                                      STAGE 1: Build geneweb
+#                                                      STAGE 1: Build Geneweb
 ###############################################################################
-FROM ocaml/opam:debian-12-ocaml-4.14 AS builder
+
+FROM ocaml/opam:debian-ocaml-4.14-nnp AS builder
+
 ENV OPAMYES=yes
-
-# Install required packages for build
 USER root
-
 # Ignore the apt warning here as apt-get does not allow wildcarding versions
 # hadolint ignore=DL3027
 RUN export DEBIAN_FRONTEND=noninteractive \
-    && apt-get update -q \  
-    && apt install -yq --no-install-recommends \
-        libgmp-dev=2:6.* \
-        libipc-system-simple-perl=1.* \
-        libstring-shellquote-perl=1.* \
-        perl=5.*
+&& apt install -yq --no-install-recommends \
+    m4=1.4.19-3 \
+    libgmp-dev=2:6.2.1+dfsg1-1.1 \
+    libpcre3-dev=2:8.39-15 \
+    libipc-system-simple-perl=1.30-2 \
+    xdot=1.2-3 \
+    zlib1g-dev=1:1.2.13.dfsg-1 \
+    pkg-config=1.8.1-1 \
+&& ln -sf /usr/bin/opam-2.3 /usr/bin/opam
 
-# Set up geneweb package and dependencies
 USER opam
-RUN git clone https://github.com/geneweb/geneweb.git ./geneweb \
-    && opam init --disable-sandboxing && opam update
-WORKDIR /home/opam/geneweb
-RUN opam pin add geneweb.dev . --no-action && opam depext geneweb 
+# Install problematic packages on ARM64 first to isolate any issues
+RUN eval "$(opam env)" && opam install \
+    uri.4.4.0 yojson.2.2.2 zarith.1.14
 
-# Build geneweb
-RUN opam install geneweb --deps-only \
-    && eval "$(opam env)" \
-    && ocaml ./configure.ml --release && make clean distrib
+# Install deps before cloning Geneweb to store them in a stable reusable cache
+RUN eval "$(opam env)" && opam install \
+    ancient.0.9.1 calendars.1.0.0 camlp-streams.5.0.1 camlzip.1.13 \
+    cppo.1.8.0 jingoo.1.5.0 markup.1.0.3 ppx_import.1.11.0 ppx_blob.0.7.2 \
+    stdlib-shims.0.3.0 unidecode.0.2.0 uucp.16.0.0 uunf.16.0.0 uutf.1.0.3 \
+    camlp5.8.03.01 oUnit.2.2.7 syslog.2.0.2
+
+# Clone repository and build Geneweb
+WORKDIR /home/opam/geneweb
+COPY --chown=opam:opam . .
+RUN eval "$(opam env)" && ocaml ./configure.ml --sosa-zarith && make distrib
 
 ###############################################################################
 #                                       STAGE 2: Export build via blank image
@@ -42,28 +49,36 @@ COPY --from=builder /home/opam/geneweb/distribution /
 
 FROM debian:12-slim AS container
 
-# Install runtime tools and add geneweb user
+ENV GENEWEB_HOME=/usr/local/share/geneweb
+ENV GENEWEB_DATA_PATH=${GENEWEB_HOME}/share/data
+ENV GWSETUP_IP=172.17.0.1
+
+# Install runtime tools and add Geneweb user
 # Ignore the apt warning here as apt-get does not allow wildcarding versions
 # hadolint ignore=DL3027
 RUN apt-get update -q \
-    && apt install -qy --no-install-recommends sudo openssl \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && adduser --system --group --uid 1000 --home /usr/local/share/geneweb --shell /bin/bash geneweb \
-    && usermod -aG sudo geneweb \
-    && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+  && apt install -qy --no-install-recommends sudo openssl \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && adduser --system --group --uid 1000 \
+     --home ${GENEWEB_HOME} --shell /bin/bash geneweb \
+  && usermod -aG sudo geneweb \
+  && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # Add required directories and copy geneweb distribution
 USER geneweb
-WORKDIR /usr/local/share/geneweb
-RUN mkdir -p bin etc log share/data share/dist \
-    && echo "172.17.0.1" >> etc/gwsetup_only
-COPY --from=builder /home/opam/geneweb/distribution share/dist
-COPY geneweb-launch.sh bin/geneweb-launch.sh
+WORKDIR ${GENEWEB_HOME}
 
+# Create directory structure and configure
+RUN mkdir -p bin etc log share/data share/dist \
+  && echo "${GWSETUP_IP}" >> etc/gwsetup_only
+
+# Copy application files
+COPY --from=builder /home/opam/geneweb/distribution share/dist
+COPY docker/geneweb-launch.sh bin/geneweb-launch.sh
+
+# Configure container
 EXPOSE 2316-2317
-VOLUME [ "/usr/local/share/geneweb/share/data", "/usr/local/share/geneweb/etc" ]
-ENV GENEWEB_DATA_PATH=/usr/local/share/geneweb/share/data
-ENV GENEWEB_HOME=/usr/local/share/geneweb
+VOLUME [ "${GENEWEB_DATA_PATH}", "${GENEWEB_HOME}/etc" ]
 
 CMD [ "bin/geneweb-launch.sh" ]

--- a/docker/geneweb-launch.sh
+++ b/docker/geneweb-launch.sh
@@ -73,9 +73,10 @@ start() {
 	-daemon \
 	-plugins -unsafe ${GENEWEB_HOME}/share/dist/gw/plugins \
 	-trace_failed_passwd \
+	-bd ${GENEWEB_DATA_PATH} \
 	-hd ${GENEWEB_HOME}/share/dist/gw \
+	-cache-in-memory
 	-log ${GENEWEB_HOME}/log/gwd.log \
-        -bd ${GENEWEB_DATA_PATH} \
 	$AUTH_ARG 2>&1
 	gwlaunch_log "-- Started gwd!"
 


### PR DESCRIPTION
- Separated AMD64 and ARM64 build jobs for better clarity and independent caching
- Improved caching strategy using GitHub Actions cache with platform-specific scopes
  - Reduced build times from 6 min (AMD64) and 40 min (ARM64) to 2 and 4 min respectively
- Optimized Dockerfile build stages:
  - Updated base image to debian-ocaml-4.14-nnp with `-cache-in-memory` gwd option
  - Added precise package version pinning for cache stability
  - Used `--chown=opam:opam` during copy to ensure correct permissions and Geneweb rebuild
- Standardized Docker build configuration across platforms
  - Added `BUILDKIT_PROGRESS=plain` for clearer build logs
  - Maintained FAST_BUILD logic for non-master branches